### PR TITLE
Reverted changes made to create-release.yml workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,8 +17,6 @@ jobs:
           echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.facts.outputs.SOURCE_TAG }}
       - name: Install the dependencies
         run: ./docker-npm install
       - name: Build


### PR DESCRIPTION
Removed Checkout.ref parameter: useless the version built match the tag (the workflows triggered are the one existing at the commit tagged).