### PR TITLE
Add My Bowling tab with current score and recent history

### DIFF
--- a/src/BottomNavView.ts
+++ b/src/BottomNavView.ts
@@ -1,0 +1,46 @@
+type TabChangeCallback = (tab: string) => void
+
+class BottomNavView {
+    private nav: HTMLElement
+    private gameButton: HTMLElement
+    private myBowlingButton: HTMLElement
+    private callback: TabChangeCallback | null
+
+    public constructor(rootElement: HTMLElement) {
+        this.callback = null
+
+        this.nav = document.createElement('div')
+        this.nav.id = 'bottom-nav'
+        this.nav.classList.add('bottom-nav')
+
+        this.gameButton = document.createElement('div')
+        this.gameButton.classList.add('bottom-nav-item')
+        this.gameButton.classList.add('active')
+        this.gameButton.textContent = "게임"
+
+        this.myBowlingButton = document.createElement('div')
+        this.myBowlingButton.classList.add('bottom-nav-item')
+        this.myBowlingButton.textContent = "마이볼링"
+
+        this.nav.appendChild(this.gameButton)
+        this.nav.appendChild(this.myBowlingButton)
+
+        rootElement.appendChild(this.nav)
+
+        this.gameButton.addEventListener('click', () => this.selectTab('game'))
+        this.myBowlingButton.addEventListener('click', () => this.selectTab('my-bowling'))
+    }
+
+    private selectTab(tab: string): void {
+        this.gameButton.classList.toggle('active', tab === 'game')
+        this.myBowlingButton.classList.toggle('active', tab === 'my-bowling')
+        if (this.callback !== null)
+            this.callback(tab)
+    }
+
+    public attachTabChangeCallback(callback: TabChangeCallback): void {
+        this.callback = callback
+    }
+}
+
+export { BottomNavView }

--- a/src/Init.ts
+++ b/src/Init.ts
@@ -3,14 +3,41 @@ import { Game } from "./Game"
 import { GameView } from "./GameView"
 import { Player } from "./Player"
 import { ConfettiView } from "./ConfettiView"
+import { MyBowlingView } from "./MyBowlingView"
+import { BottomNavView } from "./BottomNavView"
 
 function init() {
     const mainContainer = document.getElementById("main-container")
+
+    const myBowlingContainer = document.createElement('div')
+    myBowlingContainer.id = 'my-bowling-container'
+    myBowlingContainer.classList.add('centered-div')
+    myBowlingContainer.classList.add('main-container')
+    myBowlingContainer.classList.add('hidden')
+    mainContainer.parentElement.insertBefore(myBowlingContainer, mainContainer.nextSibling)
+
+    const myBowlingView = new MyBowlingView(myBowlingContainer)
+
+    const bottomNav = new BottomNavView(document.body)
+    bottomNav.attachTabChangeCallback((tab: string) => {
+        if (tab === 'my-bowling') {
+            mainContainer.classList.add('hidden')
+            myBowlingContainer.classList.remove('hidden')
+            myBowlingView.refresh()
+        }
+        else {
+            mainContainer.classList.remove('hidden')
+            myBowlingContainer.classList.add('hidden')
+        }
+    })
+
     const configFormView = new ConfigFormView(mainContainer)
-    configFormView.attachGameCreationCallback(initGame)
+    configFormView.attachGameCreationCallback((view: ConfigFormView, nbPlayers: number, nbPins: number) => {
+        initGame(view, nbPlayers, nbPins, myBowlingView)
+    })
 }
 
-function initGame(configFormView: ConfigFormView, nbPlayers: number, nbPins: number) {
+function initGame(configFormView: ConfigFormView, nbPlayers: number, nbPins: number, myBowlingView: MyBowlingView) {
     let game
     try {
         game = new Game(nbPlayers, nbPins)
@@ -25,6 +52,7 @@ function initGame(configFormView: ConfigFormView, nbPlayers: number, nbPins: num
 
     const mainContainer = document.getElementById("main-container")
     const gameView = new GameView(mainContainer, game, configFormView.getTitle())
+    myBowlingView.setCurrentGame(game)
 
 
     // Input handler callback and game logic
@@ -38,9 +66,11 @@ function initGame(configFormView: ConfigFormView, nbPlayers: number, nbPins: num
                 game.nextPlayer(); // updating current player
 
             gameView.update(game.getCurrentPlayer().getRemainingPins(), game.getPlayers()); //geting the new current player
+            myBowlingView.updateCurrentScore();
             if (game.hasEnded())
             {
                 gameView.displayWinner(game.getWinners());
+                myBowlingView.saveRecord(game.getPlayers(), game.getPins());
                 partyTime();
             }
         }

--- a/src/MyBowlingView.ts
+++ b/src/MyBowlingView.ts
@@ -1,0 +1,142 @@
+import { Game } from "./Game"
+import { Player } from "./Player"
+
+interface GameRecord {
+    date: string
+    nbPins: number
+    players: Array<{ name: string, score: number }>
+}
+
+const STORAGE_KEY = "tenpins-history"
+const MAX_RECORDS = 20
+
+class MyBowlingView {
+    private container: HTMLElement
+    private currentScoreDiv: HTMLElement
+    private historyDiv: HTMLElement
+    private currentGame: Game | null
+
+    public constructor(rootElement: HTMLElement) {
+        this.currentGame = null
+
+        this.container = document.createElement('div')
+        this.container.classList.add('pretty-container')
+        this.container.classList.add('my-bowling-view-div')
+
+        const title = document.createElement('div')
+        title.classList.add('game-title')
+        title.textContent = "마이볼링"
+
+        const currentScoreTitle = document.createElement('div')
+        currentScoreTitle.classList.add('my-bowling-section-title')
+        currentScoreTitle.textContent = "현재 점수"
+
+        this.currentScoreDiv = document.createElement('div')
+        this.currentScoreDiv.classList.add('my-bowling-current-score')
+
+        const historyTitle = document.createElement('div')
+        historyTitle.classList.add('my-bowling-section-title')
+        historyTitle.textContent = "최근 기록"
+
+        this.historyDiv = document.createElement('div')
+        this.historyDiv.classList.add('my-bowling-history')
+
+        this.container.appendChild(title)
+        this.container.appendChild(currentScoreTitle)
+        this.container.appendChild(this.currentScoreDiv)
+        this.container.appendChild(historyTitle)
+        this.container.appendChild(this.historyDiv)
+
+        rootElement.appendChild(this.container)
+
+        this.renderCurrentScore()
+        this.renderHistory()
+    }
+
+    public setCurrentGame(game: Game | null): void {
+        this.currentGame = game
+        this.renderCurrentScore()
+    }
+
+    public updateCurrentScore(): void {
+        this.renderCurrentScore()
+    }
+
+    public refresh(): void {
+        this.renderCurrentScore()
+        this.renderHistory()
+    }
+
+    public saveRecord(players: Array<Player>, nbPins: number): void {
+        const record: GameRecord = {
+            date: new Date().toLocaleString(),
+            nbPins: nbPins,
+            players: players.map(p => {
+                const scores = p.computeAccumulatedScores()
+                return { name: p.getName(), score: scores.length > 0 ? scores[scores.length - 1] : 0 }
+            })
+        }
+
+        const history = this.loadHistory()
+        history.unshift(record)
+        while (history.length > MAX_RECORDS)
+            history.pop()
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(history))
+
+        this.renderHistory()
+    }
+
+    private loadHistory(): Array<GameRecord> {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY)
+            return raw ? JSON.parse(raw) : []
+        }
+        catch (e) {
+            return []
+        }
+    }
+
+    private renderCurrentScore(): void {
+        this.currentScoreDiv.innerHTML = ""
+
+        if (this.currentGame === null) {
+            const empty = document.createElement('p')
+            empty.textContent = "진행 중인 게임이 없습니다"
+            this.currentScoreDiv.appendChild(empty)
+            return
+        }
+
+        const list = document.createElement('ul')
+        for (const player of this.currentGame.getPlayers()) {
+            const scores = player.computeAccumulatedScores()
+            const score = scores.length > 0 ? scores[scores.length - 1] : 0
+            const li = document.createElement('li')
+            li.textContent = player.getName() + " : " + score
+            list.appendChild(li)
+        }
+        this.currentScoreDiv.appendChild(list)
+    }
+
+    private renderHistory(): void {
+        this.historyDiv.innerHTML = ""
+
+        const history = this.loadHistory()
+        if (history.length === 0) {
+            const empty = document.createElement('p')
+            empty.textContent = "기록이 없습니다"
+            this.historyDiv.appendChild(empty)
+            return
+        }
+
+        const list = document.createElement('ul')
+        for (const record of history) {
+            const li = document.createElement('li')
+            const scoresText = record.players.map(p => p.name + " " + p.score).join(', ')
+            li.textContent = record.date + " - " + scoresText
+            list.appendChild(li)
+        }
+        this.historyDiv.appendChild(list)
+    }
+}
+
+export { MyBowlingView }

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,7 @@
 body {
     margin: 0;
     padding: var(--size1);
+    padding-bottom: 3.5rem;
     box-sizing: border-box;
     background:  url("./images/background.png");
     background-repeat: no-repeat;
@@ -24,7 +25,7 @@ body {
 /* COMMON */
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .main-container {
@@ -341,4 +342,61 @@ td {
 
 .player-div {
     overflow: scroll;
+}
+
+/* BOTTOM NAV */
+
+.bottom-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: row;
+    background: rgba(255,255,255,0.9);
+    border-top: 1px solid black;
+    z-index: 2;
+}
+
+.bottom-nav-item {
+    flex: 1;
+    text-align: center;
+    padding: var(--size1);
+    cursor: pointer;
+    font-size: var(--size1);
+}
+
+.bottom-nav-item.active {
+    color: red;
+    font-weight: bold;
+}
+
+/* MY BOWLING VIEW */
+
+.my-bowling-view-div {
+    background: rgba(255,255,255,0.7);
+    text-align: left;
+}
+
+.my-bowling-section-title {
+    font-size: var(--size1);
+    font-weight: bold;
+    margin-top: var(--size2);
+    margin-bottom: var(--size1);
+}
+
+.my-bowling-current-score ul,
+.my-bowling-history ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    max-height: 30vh;
+}
+
+.my-bowling-current-score li,
+.my-bowling-history li {
+    font-size: var(--size1);
+    padding: 4px 0;
+    border-bottom: 1px solid rgba(0,0,0,0.2);
 }

--- a/test/ConfigFormView.spec.ts
+++ b/test/ConfigFormView.spec.ts
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom'
 import {ConfigFormView} from "../src/ConfigFormView"
 // import {Game} from "../src/Game"
 import {initGame} from "../src/Init"
+import {MyBowlingView} from "../src/MyBowlingView"
 
 const html = fs.readFileSync(path.resolve(__dirname, "../src/index.html"))
 
@@ -56,7 +57,10 @@ describe('ConfigFormView', () => {
         document.documentElement.innerHTML = html.toString();
         const mainContainer = document.getElementById('main-container');
         view = new ConfigFormView(mainContainer);
-        view.attachGameCreationCallback(initGame);
+        const myBowlingView = new MyBowlingView(document.createElement('div'));
+        view.attachGameCreationCallback((view_, nbPlayers_, nbPins_) => {
+            initGame(view_, nbPlayers_, nbPins_, myBowlingView);
+        });
 
         configForm = document.querySelector('#config-form');
         expect(configForm).not.toBeNull();


### PR DESCRIPTION
## Summary
- Adds a bottom navigation bar with Game / My Bowling tabs
- My Bowling tab shows the current game's live score and a localStorage-backed history of recent finished games
- Fixes a CSS specificity bug where `.hidden` was overridden by `.main-container`'s `display: flex` rule declared later in the stylesheet

## Test plan
- [x] `npm run test` — all existing suites pass
- [x] `npm run build` — builds cleanly
- [x] Manually drove the built app with Playwright: started a game, confirmed the My Bowling tab shows live score, finished a game, confirmed it appears in recent history